### PR TITLE
v0.0.3

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -17,4 +17,4 @@ help:
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
 %: Makefile
-	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+	@$(SPHINXBUILD) -b $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)


### PR DESCRIPTION
## 🔨 変更内容

This pull request includes a small change to the `docs/Makefile`. The change modifies the Sphinx build command to use the `-b` option instead of the `-M` option.

* [`docs/Makefile`](diffhunk://#diff-cdec797dddf8fc387304501d6bd4f318e1e9067c6fae012dfa8b69fd85fd3248L20-R20): Changed `@$(SPHINXBUILD) -M $@` to `@$(SPHINXBUILD) -b $@` for the Sphinx build command.

## 💡 特筆事項

## 📸 スクリーンショット

## ✅ 解決するイシュー

## 🤝 関連するイシュー
